### PR TITLE
Multiple changes.

### DIFF
--- a/4bash.sh
+++ b/4bash.sh
@@ -87,11 +87,13 @@ done
 if $lurkmode ; then
     args=''
     [[ $loop == false ]] && args='--once'
-    #TODO doc
+    ## In 'lurk mode' 4bash scans whole board for threads that has subject or comment matching regular expression (incasesensitive, PCRE) provided by user
     for no in $(wget --quiet -O - "a.4cdn.org/$board/catalog.json"   |\
 		     jq --arg regrex "$regrex" '.[] | .threads | .[] | 
 		     	      	     if (.com + "\n" + .sub | test( $regrex;"i" )) then .no  else empty end? ')
-    do "$SCRIPT" --quiet $args --refresh-time "$mins" "https://boards.4chan.org/$board/thread/$no" &
+    do
+	sleep 1 # Wait 1 second (reqired by API rules)
+	"$SCRIPT" --quiet $args --refresh-time "$mins" "https://boards.4chan.org/$board/thread/$no" &
     done
 
     exit
@@ -212,7 +214,7 @@ while true; do
     #  I initially was going to use `tput` since I just found out about it
     #   but this does the job anyway
     sec=$secs
-    [ $sec -gt 0 ] || sec=3 # If user sets refresh time to 0 wait 3 seconds. 
+    [ $sec -gt 0 ] || sec=10 # If user sets refresh time to 0 wait 10 seconds to follow API rules. 
     while [ $sec -gt 0 ]; do
 	if ! $quiet ; then
             printf "Download complete. Refreshing in:  %02d\033[K\r" $sec

--- a/4bash.sh
+++ b/4bash.sh
@@ -46,7 +46,7 @@ SCRIPT="$0"
 ## Loop status
 loop=true
 
-## timestamp of the last reply
+## Timestamp of the last reply
 last_timestamp=0
 
 ## Parse commandline arguments
@@ -198,9 +198,6 @@ while true; do
     		      then ( .tim | tostring ) + .ext?, .md5 else empty end' \
 	    	    | sed '/null/d' \
 	    	    | paste -s -d' \n' )"
-	    #| tr -d ' ' \ #TMP
-	    #| sed -e "s/^/https:\/\/i.4cdn.org\/$board\//" \
-		#> $dir/$thread.files
 
 	## This loop will download files from the list with wget
 	#   using the dot style progress bar to make it pretty.
@@ -224,7 +221,7 @@ while true; do
     #
     #  I initially was going to use `tput` since I just found out about it
     #   but this does the job anyway
-    sec=10 #$secs #TMP
+    sec=$secs
     while [ $sec -gt 0 ]; do
 	if ! $quiet ; then
             printf "Download complete. Refreshing in:  %02d\033[K\r" $sec

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A 4chan image downloader in bash
 
 
 # Dependancies
->=jq-1.5
+\>=jq-1.5

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ A 4chan image downloader in bash
 
 
 # Dependancies
-jq
+>=jq-1.5


### PR DESCRIPTION
This commit does not add new features, but it introduce some optimizations.
- wget send requests only for new files (now it doesn't spam terminal with 'File ... is already here...')
- Temporary files $thread.files and $catalog_temp are removed, $thread.json changes only when new reply arrives.
- Validate files using checksums. 
- Some little bugfixes. 
- Add delays to follow API rules.
- declare dependency on >=jq-1.5