### PR TITLE
Some bugfixes, daemon mode and custom user-agent added

### DIFF
--- a/4bash.sh
+++ b/4bash.sh
@@ -49,6 +49,9 @@ loop=true
 ## Timestamp of the last reply
 last_timestamp=0
 
+## Useragent
+uagent='4bash'
+
 ## Parse commandline arguments
 while [[ $# -gt 0 ]]; do
 arg="$1"
@@ -88,7 +91,7 @@ if $lurkmode ; then
     args=''
     [[ $loop == false ]] && args='--once'
     ## In 'lurk mode' 4bash scans whole board for threads that has subject or comment matching regular expression (incasesensitive, PCRE) provided by user
-    for no in $(wget --quiet -O - "a.4cdn.org/$board/catalog.json"   |\
+    for no in $(wget --user-agent="$uagent" --quiet -O - "a.4cdn.org/$board/catalog.json"   |\
 		     jq --arg regrex "$regrex" '.[] | .threads | .[] | 
 		     	      	     if (.com + "\n" + .sub | test( $regrex;"i" )) then .no  else empty end? ')
     do
@@ -181,7 +184,7 @@ while true; do
     #   and output it to a variable.
     #   If file does not exist, exit
 
-    json="$(wget -O - -q "https://a.4cdn.org/$board/thread/$thread.json")" || { echo "Thread $board/$thread deleted or does not exist."; exit; }
+    json="$(wget --user-agent="$uagent" -O - -q "https://a.4cdn.org/$board/thread/$thread.json")" || { echo "Thread $board/$thread deleted or does not exist."; exit; }
 
     ## Get last replies timestamp
     timestamp="$(echo "$json" | jq '.posts | .[-1] | .time')"
@@ -218,7 +221,7 @@ while true; do
 
 	while read line ; do
 	    file="${line#* }" # Extract filename from second field with parameter expansion
-	    wget ${wgetargs} -nc -P $dir/ -c --progress=dot "https://i.4cdn.org/$board/$file"
+	    wget --user-agent="$uagent" ${wgetargs} -nc -P $dir/ -c --progress=dot "https://i.4cdn.org/$board/$file"
 	done<<<"$list"
 	
 	## Exit if requested to run once.

--- a/4bash.sh
+++ b/4bash.sh
@@ -141,12 +141,11 @@ if $lurkmode ; then
 
 	    sleep 1
 	    echo "Scanning /$board/ done."
-
-	    [[ $lurkd == false ]] && break
 	    
 	    [[ $loop == false ]] || last_timestamp=$(jq --arg board "$board" --arg last_timestamp "$last_timestamp" \
 							'( ('$last_timestamp' | fromjson) + ({ '$board':(.'$board' | .timestamp)}) ) | tojson'<<<"$json")
 	done
+	[[ $lurkd == false ]] && break
 	cwait $lsecs
 
     done

--- a/4bash.sh
+++ b/4bash.sh
@@ -17,9 +17,9 @@
 ##     script.sh <url>        ##
 ##                            ##
 ##  To download all threads   ##
-##  that match regrex:        ##
+##  that match regex:         ##
 ##     script.sh -l\          ##
-##     <board> <regrex>       ##
+##     <board> <regex>        ##
 ##                            ##
 ##  To clean:                 ##
 ##     script.sh <url> clean  ##
@@ -95,7 +95,7 @@ case $arg in
 	lurkmode=true
 	shift
 	boards="$1"
-	regrex="$2"
+	regex="$2"
 	shift
 	;;
     --daemon)
@@ -128,9 +128,9 @@ if $lurkmode ; then
     while true ; do
 	for board in ${boards//,/ } ; do
 	    json="$(wget --user-agent="$uagent" --quiet -O - "a.4cdn.org/$board/catalog.json" |\
-		jq --arg board "$board" --arg last_timestamp "$last_timestamp" --arg regrex "$regrex" \
+		jq --arg board "$board" --arg last_timestamp "$last_timestamp" --arg regex "$regex" \
 		'{'$board':{timestamp:([.[] | .threads | .[] |.tim] | sort | .[-1]), 
-		 no:[.[] | .threads | .[] | if ( .tim > ('$last_timestamp' | fromjson | .'$board' // 0) and (.com + "\n" + .sub | test( $regrex;"i" )) ) 
+		 no:[.[] | .threads | .[] | if ( .tim > ('$last_timestamp' | fromjson | .'$board' // 0) and (.com + "\n" + .sub | test( $regex;"i" )) ) 
 					     then .no else empty end?] }}' )"
 
 	    for no in $(jq --arg board "$board" '.'$board' | .no | .[]'<<<"$json")
@@ -144,8 +144,8 @@ if $lurkmode ; then
 
 	    [[ $lurkd == false ]] && break
 	    
-	    last_timestamp=$(jq --arg board "$board" --arg last_timestamp "$last_timestamp" \
-				'( ('$last_timestamp' | fromjson) + ({ '$board':(.'$board' | .timestamp)}) ) | tojson'<<<"$json")
+	    [[ $loop == false ]] || last_timestamp=$(jq --arg board "$board" --arg last_timestamp "$last_timestamp" \
+							'( ('$last_timestamp' | fromjson) + ({ '$board':(.'$board' | .timestamp)}) ) | tojson'<<<"$json")
 	done
 	cwait $lsecs
 

--- a/4bash.sh
+++ b/4bash.sh
@@ -214,15 +214,18 @@ while true; do
 			| sed '/null/d' \
 			| paste -s -d' \n' )"	    
 	fi
-	   
+
+	
 
 	## This loop will download files from the list with wget
 	#   using the dot style progress bar to make it pretty.
 
 	while read line ; do
+	    [ ! "$line" ] && break # If filename is empty (empty list, there is no new file), break
 	    file="${line#* }" # Extract filename from second field with parameter expansion
 	    wget --user-agent="$uagent" ${wgetargs} -nc -P $dir/ -c --progress=dot "https://i.4cdn.org/$board/$file"
 	done<<<"$list"
+
 	
 	## Exit if requested to run once.
 	if ! $loop ; then

--- a/4bash.sh
+++ b/4bash.sh
@@ -34,11 +34,17 @@ quiet=false
 ## Download all threads with subject or comment maching regular expression (PCRE, incasesensetive)
 lurkmode=false
 
+## Lurk daemon mode
+lurkd=false
+
 ## Remove broken files
 cleanmode=false
 
 ## Refresh time
 mins=1
+
+## 'Lurk daemon' interval
+lmins=15
 
 ## Path to 4bash
 SCRIPT="$0"
@@ -51,6 +57,22 @@ last_timestamp=0
 
 ## Useragent
 uagent='4bash'
+
+function cwait {
+    #  I initially was going to use `tput` since I just found out about it
+    #   but this does the job anyway
+    sec=$1
+    [ $sec -gt 0 ] || sec=10 # If user sets refresh time to 0 wait 10 seconds to follow API rules. 
+    while [ $sec -gt 0 ]; do
+	if ! $quiet ; then
+            printf "Download complete. Refreshing in:  %02d\033[K\r" $sec
+	fi
+	sleep 1
+        : $((sec--))
+    done
+    [[ $quiet == false ]] && echo # Print newline
+}
+
 
 ## Parse commandline arguments
 while [[ $# -gt 0 ]]; do
@@ -65,12 +87,19 @@ case $arg in
 	shift
 	mins="$1"
 	;;
+    --scan-interval)
+	shift
+	lmins="$1"	
+	;;
     -l|--lurk)
 	lurkmode=true
 	shift
 	board="$1"
 	regrex="$2"
 	shift
+	;;
+    --daemon)
+	lurkd=true
 	;;
     -1|--once|once)
 	loop=false
@@ -86,22 +115,41 @@ shift
 
 done
 
+## Lurkd interval in seconds
+lsecs=$(($lmins * 60))
+
 ## If user selected 'lurk mode'
 if $lurkmode ; then
     args=''
+    last_timestamp=0
     [[ $loop == false ]] && args='--once'
     ## In 'lurk mode' 4bash scans whole board for threads that has subject or comment matching regular expression (incasesensitive, PCRE) provided by user
-    for no in $(wget --user-agent="$uagent" --quiet -O - "a.4cdn.org/$board/catalog.json"   |\
-		     jq --arg regrex "$regrex" '.[] | .threads | .[] | 
-		     	      	     if (.com + "\n" + .sub | test( $regrex;"i" )) then .no  else empty end? ')
-    do
-	sleep 1 # Wait 1 second (reqired by API rules)
-	"$SCRIPT" --quiet $args --refresh-time "$mins" "https://boards.4chan.org/$board/thread/$no" &
-    done
+    # TODO doc
+    while true ; do
+	list_tstamp="$(wget --user-agent="$uagent" --quiet -O - "a.4cdn.org/$board/catalog.json" |\
+	    jq --arg ltstamp "$last_timestamp" --arg regrex "$regrex" \
+	    '{timestamp:([.[] | .threads | .[] |.tim] | sort | .[-1]), 
+	      no:[.[] | .threads | .[] | if ( (.tim > ($ltstamp | tonumber)) and (.com + "\n" + .sub | test( $regrex;"i" )) ) 
+	      	      		       	 then .no else empty end?] }' )"
+	
 
-    sleep 1
-    echo Done.
-    
+	last_timestamp=$(jq '.timestamp'<<<"$list_tstamp")
+
+	for no in $(jq '.no | .[]'<<<"$list_tstamp")
+	do
+	    sleep 1 # Wait 1 second (reqired by API rules)
+	    "$SCRIPT" --quiet $args --refresh-time "$mins" "https://boards.4chan.org/$board/thread/$no" &
+	done
+
+	sleep 1
+	echo Done.
+	
+	[[ $lurkd == false ]] && break
+
+	cwait $lsecs	
+
+    done
+        
     exit
 
 fi
@@ -215,8 +263,6 @@ while true; do
 			| paste -s -d' \n' )"	    
 	fi
 
-	
-
 	## This loop will download files from the list with wget
 	#   using the dot style progress bar to make it pretty.
 
@@ -236,20 +282,8 @@ while true; do
 	last_timestamp=$timestamp
     fi
 
-    ## This while loop will redo the whole thing after the given amount
+    ## This function will redo the whole thing after the given amount
     #   of refresh seconds
-    #
-    #  I initially was going to use `tput` since I just found out about it
-    #   but this does the job anyway
-    sec=$secs
-    [ $sec -gt 0 ] || sec=10 # If user sets refresh time to 0 wait 10 seconds to follow API rules. 
-    while [ $sec -gt 0 ]; do
-	if ! $quiet ; then
-            printf "Download complete. Refreshing in:  %02d\033[K\r" $sec
-	fi
-	sleep 1
-        : $((sec--))
-    done
-    [[ $quiet == false ]] && echo # Print newline
+    cwait $secs
 
 done


### PR DESCRIPTION
New staff:
- Close #3  ,  /f/ works now
- 4bash now does not download index.html
- Daemon mode added. when `--daemon --lurk ...` is set 4bash will rescan boards for threads matching regex after selected interval (default 15 mins)
- in 'lurk mode' user can now set comma separated list of boards
- now user-agent is  '4bash' when accessing API and downloading files